### PR TITLE
wip: Terraformでネットワーク部分を構成

### DIFF
--- a/image_delivery_system/.gitignore
+++ b/image_delivery_system/.gitignore
@@ -1,0 +1,35 @@
+# Local .terraform directories
+**/.terraform/*
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/image_delivery_system/README.md
+++ b/image_delivery_system/README.md
@@ -1,10 +1,4 @@
-# infra_practice
-
-## Terraform のプロジェクトを参照する
-
-```
-cd image_delivery_system
-```
+# ft-terraform
 
 ## 初期化
 

--- a/image_delivery_system/environments/dev/main_virginia.tf
+++ b/image_delivery_system/environments/dev/main_virginia.tf
@@ -1,0 +1,54 @@
+module "vpc" {
+  source      = "../../modules/vpc"
+  environment = "dev"
+  system_name = "image_delivery_system"
+  vpc_cidr    = "172.32.0.0/16"
+}
+
+module "public_subnet" {
+  source      = "../../modules/subnet"
+  vpc_id      = module.vpc.vpc_id
+  environment = "dev"
+  system_name = "image_delivery_system"
+  subnet_map_list = [
+    { "name" = "public-1a", "cidr" = "172.32.1.0/24", "az_name" = "us-east-1a" },
+    { "name" = "public-1c", "cidr" = "172.32.2.0/24", "az_name" = "us-east-1c" },
+    { "name" = "public-1d", "cidr" = "172.32.3.0/24", "az_name" = "us-east-1d" },
+  ]
+}
+module "private_subnet" {
+  source      = "../../modules/subnet"
+  vpc_id      = module.vpc.vpc_id
+  environment = "dev"
+  system_name = "image_delivery_system"
+  subnet_map_list = [
+    { "name" = "private-1a", "cidr" = "172.32.4.0/24", "az_name" = "us-east-1a" },
+    { "name" = "private-1c", "cidr" = "172.32.5.0/24", "az_name" = "us-east-1c" },
+    { "name" = "private-1d", "cidr" = "172.32.6.0/24", "az_name" = "us-east-1d" },
+  ]
+}
+
+module "route_table_public" {
+  source              = "../../modules/route_table/route_table"
+  vpc_id              = module.vpc.vpc_id
+  internet_gateway_id = module.vpc.internet_gateway_id
+  environment         = "dev"
+  system_name         = "image_delivery_system"
+}
+
+module "route_table_association_public" {
+  source         = "../../modules/route_table/route_table_association"
+  route_table_id = module.route_table_public.route_table_id
+  for_each       = module.public_subnet.subnets
+  subnet_id      = each.value
+}
+
+module "nat_gateway" {
+  source         = "../../modules/nat_gateway"
+  # for_each       = module.public_subnet.subnets
+  # subnet_id      = each.value
+  subnet_id      = module.public_subnet.subnets["us-east-1a"]
+  vpc_id         = module.vpc.vpc_id
+  environment    = "dev"
+  system_name    = "image_delivery_system"
+}

--- a/image_delivery_system/environments/dev/provider.tf
+++ b/image_delivery_system/environments/dev/provider.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/image_delivery_system/modules/nat_gateway/main.tf
+++ b/image_delivery_system/modules/nat_gateway/main.tf
@@ -1,0 +1,34 @@
+# Elastic IP
+resource "aws_eip" "nat" {
+  tags = {
+    Name = join("-", [var.system_name, var.environment, "natgw", var.subnet_id])
+  }
+}
+
+# NAT Gateway
+resource "aws_nat_gateway" "nat" {
+  subnet_id = var.subnet_id
+  allocation_id = aws_eip.nat.id # 紐付けるElasti IP
+
+  tags = {
+    Name = join("-", [var.system_name, var.environment, var.subnet_id])
+  }
+}
+
+resource "aws_route_table" "private" {
+  vpc_id              = var.vpc_id
+  tags = {
+    Name = join("-", [var.system_name, var.environment, var.subnet_id])
+  }
+}
+
+# resource "aws_route" "main" {
+#   route_table_id         = aws_route_table.main.id
+#   destination_cidr_block = "0.0.0.0/0"
+#   nat_gateway_id = aws_nat_gateway.nat.id
+# }
+
+resource "aws_route_table_association" "private" {
+  subnet_id          = var.subnet_id
+  route_table_id     = aws_route_table.private.id
+}

--- a/image_delivery_system/modules/nat_gateway/variables.tf
+++ b/image_delivery_system/modules/nat_gateway/variables.tf
@@ -1,0 +1,17 @@
+variable "system_name" {
+  type        = string
+  description = "システム名称：本システムの名称を指定。一意な名称にすること"
+}
+
+variable "environment" {
+  type        = string
+  description = "環境面の名前：dev, stg, prdなどを指定。一意な名称にすること"
+}
+variable "vpc_id" {
+  type        = string
+  description = "VPCのID"
+}
+variable "subnet_id" {
+  type        = string
+  description = "サブネットのID"
+}

--- a/image_delivery_system/modules/route_table/route_table/main.tf
+++ b/image_delivery_system/modules/route_table/route_table/main.tf
@@ -1,0 +1,14 @@
+# Route Table
+resource "aws_route_table" "public" {
+  vpc_id = var.vpc_id
+  tags = {
+    Name = join("-", [var.system_name, var.environment, "public"])
+  }
+}
+
+# Route
+resource "aws_route" "public" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = var.internet_gateway_id
+}

--- a/image_delivery_system/modules/route_table/route_table/outputs.tf
+++ b/image_delivery_system/modules/route_table/route_table/outputs.tf
@@ -1,0 +1,3 @@
+output "route_table_id" {
+  value = aws_route_table.public.id
+}

--- a/image_delivery_system/modules/route_table/route_table/variables.tf
+++ b/image_delivery_system/modules/route_table/route_table/variables.tf
@@ -1,0 +1,20 @@
+variable "system_name" {
+  type        = string
+  description = "システム名称：本システムの名称を指定。一意な名称にすること"
+}
+
+variable "environment" {
+  type        = string
+  description = "環境面の名前：dev, stg, prdなどを指定。一意な名称にすること"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPCのID"
+}
+
+variable "internet_gateway_id" {
+  type        = string
+  default = null
+  description = "インターネットゲートウェイのID"
+}

--- a/image_delivery_system/modules/route_table/route_table_association/main.tf
+++ b/image_delivery_system/modules/route_table/route_table_association/main.tf
@@ -1,0 +1,5 @@
+# Association
+resource "aws_route_table_association" "public" {
+  subnet_id     = var.subnet_id
+  route_table_id = var.route_table_id
+}

--- a/image_delivery_system/modules/route_table/route_table_association/variables.tf
+++ b/image_delivery_system/modules/route_table/route_table_association/variables.tf
@@ -1,0 +1,9 @@
+variable "subnet_id" {
+  type        = string
+  description = "サブネットのID"
+}
+
+variable "route_table_id" {
+  type        = string
+  description = "ルートテーブルのID"
+}

--- a/image_delivery_system/modules/subnet/main.tf
+++ b/image_delivery_system/modules/subnet/main.tf
@@ -1,0 +1,11 @@
+# Subnet
+resource "aws_subnet" "main" {
+  vpc_id = var.vpc_id
+  for_each = { for i in var.subnet_map_list : i.name => i }
+  
+  availability_zone = each.value.az_name
+  cidr_block        = each.value.cidr
+  tags = {
+    Name = join("-", [var.system_name, var.environment, each.value.name])
+  }
+}

--- a/image_delivery_system/modules/subnet/outputs.tf
+++ b/image_delivery_system/modules/subnet/outputs.tf
@@ -1,0 +1,6 @@
+output "subnets" {
+  value = {
+    # i.availability_zone => i.idは、配列のKeyをavailability_zoneに設定している
+    for i in aws_subnet.main : i.availability_zone => i.id
+  }
+}

--- a/image_delivery_system/modules/subnet/variables.tf
+++ b/image_delivery_system/modules/subnet/variables.tf
@@ -1,0 +1,19 @@
+variable "system_name" {
+  type        = string
+  description = "システム名称：本システムの名称を指定。一意な名称にすること"
+}
+
+variable "environment" {
+  type        = string
+  description = "環境面の名前：dev, stg, prdなどを指定。一意な名称にすること"
+}
+
+variable "subnet_map_list" {
+  type        = list(map(string))
+  description = "サブネットのMAP"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPCのID"
+}

--- a/image_delivery_system/modules/vpc/main.tf
+++ b/image_delivery_system/modules/vpc/main.tf
@@ -1,0 +1,18 @@
+resource "aws_vpc" "main" {
+  cidr_block                           = var.vpc_cidr
+  enable_dns_hostnames                 = false
+  enable_dns_support                   = true
+  enable_network_address_usage_metrics = false
+  instance_tenancy                     = "default"
+  tags = {
+    Name = join("-", [var.system_name, var.environment])
+  }
+}
+
+# Internet Gateway
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+  tags = {
+    Name = join("-", [var.system_name, var.environment])
+  }
+}

--- a/image_delivery_system/modules/vpc/outputs.tf
+++ b/image_delivery_system/modules/vpc/outputs.tf
@@ -1,0 +1,7 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "internet_gateway_id" {
+  value = aws_internet_gateway.main.id
+}

--- a/image_delivery_system/modules/vpc/variables.tf
+++ b/image_delivery_system/modules/vpc/variables.tf
@@ -1,0 +1,14 @@
+variable "system_name" {
+  type        = string
+  description = "システム名称：本システムの名称を指定。一意な名称にすること"
+}
+
+variable "environment" {
+  type        = string
+  description = "環境面の名前：dev, stg, prdなどを指定。一意な名称にすること"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "VPCのCIDRブロック"
+}


### PR DESCRIPTION
[aws_route](https://github.com/nabe-pot/infra_practice/blob/create-networking-by-terraform/image_delivery_system/modules/route_table/route_table/main.tf#L10)の箇所をコメントアウトしても以下のエラーが出る。
`Error: creating Route Table 00000000 Association: Resource.AlreadyAssociated: the specified association for route table 000000000 conflicts with an existing association
        status code: 400, request id: 00000000000 on ../../modules/nat_gateway/main.tf line 31, in resource "aws_route_table_association" "main":
  31: resource "aws_route_table_association" "main" {
`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the main README with instructions for Terraform project referencing, initialization, simulation, deployment, destruction, and file formatting.
	- Added a detailed guide in `image_delivery_system/README.md` on using Terraform for infrastructure provisioning.

- **New Features**
	- Implemented infrastructure configuration for the development environment of an image delivery system, including VPC, subnets, route tables, and a NAT gateway.
	- Introduced AWS provider configuration specific to the development environment.
	- Added modules for managing Elastic IP, NAT Gateway, route tables, route table associations, and subnets in AWS.
	- Established resources for creating an AWS VPC and an Internet Gateway.

- **Chores**
	- Added a `.gitignore` file for the `image_delivery_system` project to exclude specific files and directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->